### PR TITLE
Fixes for Python 3.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
  - "3.5"
  - "3.6"
+ - "3.7"
+ - "3.8"
 before_install:
   - pip install --upgrade pip
 install:

--- a/flake8_sql/parser.py
+++ b/flake8_sql/parser.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, List
+from typing import Any, Generator, List, Tuple
 
 import sqlparse
 
@@ -83,7 +83,7 @@ class Parser:
                 col += len(token.value)
 
 
-def _flatten_group(token: sqlparse.sql.Token, depth: int=0) -> List[sqlparse.sql.Token]:
+def _flatten_group(token: sqlparse.sql.Token, depth: int = 0) -> List[sqlparse.sql.Token]:
     tokens = []
     for item in token.tokens:
         if item.ttype == sqlparse.tokens.DML:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33,py34,py35,py36,pep8,setuppy,manifest
+envlist = py33,py34,py35,py36,py37,py38,pep8,setuppy,manifest
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Python 3.8 changed the AST structure slightly to introduce a new field for expressions called `end_lineno`. Previously the end lineno could be obtained by just using `lineno`; for this reason we need to change our behaviour depending on which Python version is used.

This change also adds Python 3.7/3.8 to be tested in CI and fixes some new minor linting issues.

Fixes: https://github.com/pgjones/flake8-sql/issues/11