### PR TITLE
Fix wrong lineno used on Python 3.8

### DIFF
--- a/flake8_sql/linter.py
+++ b/flake8_sql/linter.py
@@ -207,7 +207,8 @@ def _ast_walk(node: ast.AST) -> Generator[ast.AST, None, None]:
         while todo:
             node = todo.popleft()
             if isinstance(node, ast.JoinedStr):
-                merged_node = ast.Str(s='', lineno=node.lineno, col_offset=node.col_offset)
+                lineno = _get_query_end_lineno(node)
+                merged_node = ast.Str(s='', lineno=lineno, col_offset=node.col_offset)
                 for child in ast.iter_child_nodes(node):
                     if isinstance(child, ast.Str):
                         merged_node.s += child.s

--- a/tests/test_cases/fstring.py
+++ b/tests/test_cases/fstring.py
@@ -1,5 +1,8 @@
 tbl = "tbl"
 query = f"SELECT ca,cb FROM {tbl}"  # Q443
-query = """SELECT abc
-           FROM   xyz
-           WHERE  def = 'def'"""  # Q447
+query = f"""SELECT abc
+            FROM   {tbl}
+            WHERE  def = 'def'"""  # Q447
+query = f"""SELECT abc
+              FROM {tbl}
+             WHERE def = 'def'"""


### PR DESCRIPTION
The node lineno was not using our helper function which correctly works
out the end lineno; this was breaking usage with multiline f-strings.

The tests have been updated to include this case.