### PR TITLE
Fixes for Python 3.9+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
  - "3.6"
  - "3.7"
  - "3.8"
+ - "3.9"
+ - "3.10"
 before_install:
   - pip install --upgrade pip
 install:

--- a/flake8_sql/linter.py
+++ b/flake8_sql/linter.py
@@ -182,13 +182,12 @@ def _get_initial_offset(query: ast.Str, physical_lines: List[str]) -> int:
 def _get_query_end_lineno(query: ast.Str) -> int:
     """Get the lineno for the last line of the given query.
 
-    In Python versions below 3.8, this could be obtained by `ast.expr.lineno`.
-    However Python 3.8 changed this to be the first line, and for the last line
-    you would instead have to use `ast.expr.end_lineno`. The real kicker here is
-    that this field is NOT required to be set by the compiler, so we have no
-    guarantee that it can be used. In practice, it is set for multi-line strings
-    which is suitable for our purposes - so we just need to handle the case for a
-    single-line string for which we can use the first lineno.
+    - Python <3.8 - `ast.expr.lineno` gives last line.
+    - Python =3.8 - Introduced `ast.expr.lineno` and `ast.expr.end_lineno` for first
+                    and last line respectively. `ast.expr.end_lineno` is only set for
+                    multi-line strings, fallback to `ast.expr.lineno` if not set.
+    - Python >3.8 - `ast.expr.end_lineno` is `None` for single-line strings, fallback
+                    to `ast.expr.lineno` if `None`.
     """
     try:
         end_lineno = query.end_lineno
@@ -196,7 +195,7 @@ def _get_query_end_lineno(query: ast.Str) -> int:
         # Should only happen for non multi-line strings or Python versions below 3.8.
         end_lineno = query.lineno
 
-    return end_lineno
+    return end_lineno or query.lineno
 
 
 def _ast_walk(node: ast.AST) -> Generator[ast.AST, None, None]:

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Quality Assurance',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,pep8,setuppy,manifest
+envlist = py3{5,6,7,8,9,10},pep8,setuppy,manifest
 
 [testenv]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     flake8
     pep8-naming
     flake8-import-order
-    flake8-strict
     sqlparse
 commands = flake8 flake8_sql/ tests/
 


### PR DESCRIPTION
#12 assumes that `end_lineno` will not be set for single-line strings. However, as of Python 3.9 (python/cpython@b7e9525f9c7ef02a1d2ad8253afdeb733b0951d4) these fields are instead defaulted to `None`.

Also add testing for Python 3.9/3.10 and drop unmaintained `flake8-strict` package.